### PR TITLE
Horizontal Ruler Helper

### DIFF
--- a/src/helpers/ruler.js
+++ b/src/helpers/ruler.js
@@ -1,0 +1,55 @@
+/**
+ * Add a horizontal ruler to your email
+ * 
+ * @example
+ * {{{ruler color="#ec6225" width="60px" height="3px" spacing="15px"}}}
+ * 
+ * Attribute Options
+ * color: Must be hex color value
+ * width: Can be percentage (50%) or pixel (50px) unit
+ * height: Defaults to pixel unit
+ * spacing: Default to pixel unit
+ * 
+ */
+
+module.exports = function(options) {
+
+	String.prototype.trimUnit = function() { return this.replace(/\D/g, ''); }
+	var color = options.hash.color;
+	var spacing = options.hash.spacing.trimUnit();
+	var height = options.hash.height.trimUnit();
+	var width = options.hash.width;
+	var widthType = '';
+	var trimWidth = width.trimUnit();
+	var spacer = '';
+
+	if (typeof color === 'undefined') color = '';
+	if (typeof height === 'undefined') height = '';
+	if (typeof width === 'undefined') width = '';
+
+	if (typeof spacing === 'undefined') {
+		spacer = '';
+	} else {
+		spacer = '<tr height="'+spacing+'"><td height="'+spacing+'"></td></tr>';
+	};
+
+	if(width.match('%$')) {
+		widthType = width = trimWidth+'%';
+	} else if (width.match('px$')) {
+		widthType = trimWidth+'px';
+		width = trimWidth;
+	} else {
+		widthType = 'auto';
+		width = trimWidth;
+	}
+
+	var ruler = '<table align="center" border="0" cellpadding="0" cellspacing="0" width="'+width+'" height="'+height+'" style="width:'+widthType+' !important; height: '+height+'px !important;">\
+		'+spacer+'\
+		<tr height="'+height+'"><td bgcolor="'+color+'" align="center" valign="top" width="'+width+'" height="'+height+'" style="font-size: 0%; line-height:'+height+'px; mso-line-height-rule:exactly;">\
+			<img src="https://spacergif.org/spacer.gif" width="'+width+'" height="'+height+'" />\
+		</td></tr>\
+		'+spacer+'\
+	</table>';
+
+	return ruler;
+}


### PR DESCRIPTION
Custom helper that adds a horizontal ruler to your email templates.

## Usage

`{{{ruler color="#ec6225" width="60px" height="3px" spacing="15px"}}}`

## Options

* **color:** This is the color of the ruler. Must be hex value (#000000)
* **width:** This is the width of the ruler. Can be percentage (50%) or pixel (50px) unit
* **height:** This is the height of the ruler. Defaults to pixel unit
* **spacing:** This is the spacing above and below the ruler. Defaults to pixel unit

## Example

![ruler](https://cloud.githubusercontent.com/assets/4481041/23199644/ab21a94c-f89d-11e6-96e7-09f064ad6c39.jpg)